### PR TITLE
Update doc to point to middleware location

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ Add the middleware:
 ::
 
 	MIDDLEWARE_CLASSES = (
-		'viewas.ViewAsMiddleware',
+		'viewas.middleware.ViewAsMiddleware',
 	)
 
 Register the application within INSTALLED_APPS:


### PR DESCRIPTION
Current the middleware exists in viewas.middleware I figured I'd update the doc so copy paste works nicer.  :smile_cat: 
