### PR TITLE
Remove css that conflicts with existing sites

### DIFF
--- a/src/viewas/templates/viewas/header.html
+++ b/src/viewas/templates/viewas/header.html
@@ -1,12 +1,5 @@
 <style type="text/css">
-body {
-    padding-top: 35px;
-}
 #login_as {
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
     background: #000;
     font-size: 12px;
     height: 35px;


### PR DESCRIPTION
Not sure if this is the direction you'd like to go, but I removed the CSS that placed the toolbar at the top.  It conflicts with a position fixed nav bar, which a lot of sites use.  This now places the black bar at the bottom of the page.  If the better direction to go is configurable CSS I'm happy to do that as well.  Just let me know, though there would be to just not include the CSS in the template and let the consuming site style  `#login_as` themselves.  

I also removed the redefinition of the body css `padding-top` because it conflicts with existing styles on some sites. 

p.s.  This is an awesome middleware for testing and verifying things,  :+1: for this app.